### PR TITLE
fix: fix streaming response on google provider

### DIFF
--- a/core/providers/google/src/models/chat-models/base-chat-model.google.ts
+++ b/core/providers/google/src/models/chat-models/base-chat-model.google.ts
@@ -850,7 +850,12 @@ class BaseChatModel implements ChatModelV1<ChatModelSchemaType> {
           }
         }
 
-        if (parsedResponse.usageMetadata) {
+        if (
+          parsedResponse.usageMetadata &&
+          parsedResponse.usageMetadata.totalTokenCount &&
+          parsedResponse.usageMetadata.promptTokenCount &&
+          parsedResponse.usageMetadata.candidatesTokenCount
+        ) {
           partialResponse.usage = {
             promptTokens: parsedResponse.usageMetadata.promptTokenCount,
             completionTokens: parsedResponse.usageMetadata.candidatesTokenCount,

--- a/core/providers/google/src/models/chat-models/types/response.chat-model.google.ts
+++ b/core/providers/google/src/models/chat-models/types/response.chat-model.google.ts
@@ -103,10 +103,10 @@ const GoogleStreamChatResponse = z.object({
   ),
   usageMetadata: z
     .object({
-      promptTokenCount: z.number(),
+      promptTokenCount: z.number().optional(),
       cachedContentTokenCount: z.number().optional(),
-      candidatesTokenCount: z.number(),
-      totalTokenCount: z.number(),
+      candidatesTokenCount: z.number().optional(),
+      totalTokenCount: z.number().optional(),
     })
     .optional(),
 });
@@ -119,6 +119,6 @@ export {
   GoogleStreamChatResponse,
   GoogleStreamChatTextResponse,
   GoogleStreamChatToolResponse,
-  type GoogleStreamChatResponseType,
   type GoogleCompleteChatResponseType,
+  type GoogleStreamChatResponseType,
 };


### PR DESCRIPTION
The responses received in the stream don't contain the usage metadata until the final chunk. 
Allow those chunks to be parsed correctly and set tokens in the transformed config only when complete info is received.