### PR TITLE
fix anthropic transform config method to not modify orignal configs

### DIFF
--- a/core/providers/anthropic/src/models/chat-models/base-chat-model.anthropic.ts
+++ b/core/providers/anthropic/src/models/chat-models/base-chat-model.anthropic.ts
@@ -284,9 +284,11 @@ class BaseChatModel implements ChatModelV1<ChatModelSchemaType> {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   transformConfig(config: ConfigType, messages?: MessageType[], tools?: ToolType[]): ParamsType {
     const _toolChoice = config.toolChoice;
-    delete config.toolChoice; // can have a specific tool name that is not in the model schema, validated at transformation
 
-    const _parsedConfig = this.modelSchema.config.schema.safeParse(config);
+    const _config = { ...config }; // create a copy to avoid mutating original config
+    delete _config.toolChoice; // can have a specific tool name that is not in the model schema, validated at transformation
+
+    const _parsedConfig = this.modelSchema.config.schema.safeParse(_config);
     if (!_parsedConfig.success) {
       throw new InvalidConfigError({
         info: `Invalid config for model : '${this.modelName}'`,


### PR DESCRIPTION
`delete config.toolChoice; `
modifies the config that's passed to the transform config method, which is problematic in cases where the config is also accessed later on.
This caused issues with the tool call in bedrock!
as the method is called 2 times.

First during header signature
second during getting the actual body

This creates a shallow copy of the original config to ensure it's not modified. This fixes the issue on the bedrock tool call