### PR TITLE
Add GPT-5.1 model support to OpenAI provider

### DIFF
--- a/core/providers/openai/src/models/chat-models/gpt-5-1.openai.ts
+++ b/core/providers/openai/src/models/chat-models/gpt-5-1.openai.ts
@@ -1,0 +1,38 @@
+import { z } from "zod";
+
+import { ChatModelSchema } from "@adaline/provider";
+
+import { OpenAIChatModelConfigs } from "../../configs";
+import pricingData from "../pricing.json";
+import { BaseChatModel, BaseChatModelOptions } from "./base-chat-model.openai";
+import { OpenAIChatModelModalities, OpenAIChatModelModalitiesEnum, OpenAIChatModelRoles, OpenAIChatModelRolesMap } from "./types";
+
+const GPT_5_1Literal = "gpt-5.1";
+const GPT_5_1Description =
+  "Latest flagship GPT-5.1 model for coding and agentic tasks with configurable reasoning effort. \
+  Training data up to September 2024.";
+
+const GPT_5_1Schema = ChatModelSchema(OpenAIChatModelRoles, OpenAIChatModelModalitiesEnum).parse({
+  name: GPT_5_1Literal,
+  description: GPT_5_1Description,
+  maxInputTokens: 400000,
+  maxOutputTokens: 128000,
+  roles: OpenAIChatModelRolesMap,
+  modalities: OpenAIChatModelModalities,
+  config: {
+    def: OpenAIChatModelConfigs.gpt5(128000, 4).def,
+    schema: OpenAIChatModelConfigs.gpt5(128000, 4).schema,
+  },
+  price: pricingData[GPT_5_1Literal],
+});
+
+const GPT_5_1Options = BaseChatModelOptions;
+type GPT_5_1OptionsType = z.infer<typeof GPT_5_1Options>;
+
+class GPT_5_1 extends BaseChatModel {
+  constructor(options: GPT_5_1OptionsType) {
+    super(GPT_5_1Schema, options);
+  }
+}
+
+export { GPT_5_1, GPT_5_1Literal, GPT_5_1Options, GPT_5_1Schema, type GPT_5_1OptionsType };

--- a/core/providers/openai/src/models/chat-models/index.ts
+++ b/core/providers/openai/src/models/chat-models/index.ts
@@ -9,6 +9,7 @@ export * from "./gpt-4-1.openai";
 export * from "./gpt-4-1-mini.openai";
 export * from "./gpt-4-1-nano.openai";
 export * from "./gpt-5.openai";
+export * from "./gpt-5-1.openai";
 export * from "./gpt-5-mini.openai";
 export * from "./gpt-5-nano.openai";
 export * from "./gpt-5-chat-latest.openai";

--- a/core/providers/openai/src/models/pricing.json
+++ b/core/providers/openai/src/models/pricing.json
@@ -478,5 +478,21 @@
         }
       }
     ]
+  },
+  "gpt-5.1": {
+    "modelName": "gpt-5.1",
+    "currency": "USD",
+    "tokenRanges": [
+      {
+        "minTokens": 0,
+        "maxTokens": null,
+        "prices": {
+          "base": {
+            "inputPricePerMillion": 1.25,
+            "outputPricePerMillion": 10.0
+          }
+        }
+      }
+    ]
   }
 }

--- a/core/providers/openai/src/provider/provider.openai.ts
+++ b/core/providers/openai/src/provider/provider.openai.ts
@@ -68,6 +68,11 @@ class OpenAI<C extends Models.BaseChatModelOptionsType, E extends Models.BaseEmb
       modelOptions: Models.GPT_5Options,
       modelSchema: Models.GPT_5Schema,
     },
+    [Models.GPT_5_1Literal]: {
+      model: Models.GPT_5_1,
+      modelOptions: Models.GPT_5_1Options,
+      modelSchema: Models.GPT_5_1Schema,
+    },
     [Models.GPT_5_MiniLiteral]: {
       model: Models.GPT_5_Mini,
       modelOptions: Models.GPT_5_MiniOptions,

--- a/core/providers/vertex/package.json
+++ b/core/providers/vertex/package.json
@@ -58,7 +58,7 @@
     "@adaline/google": "workspace:*",
     "@adaline/provider": "workspace:*",
     "@adaline/types": "workspace:*",
-    "jose": "^5.2.0",
+    "jose": "^5.10.0",
     "zod": "^3.23.8"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -322,7 +322,7 @@ importers:
         specifier: workspace:*
         version: link:../../../packages/types
       jose:
-        specifier: ^5.2.0
+        specifier: ^5.10.0
         version: 5.10.0
       zod:
         specifier: ^3.23.8


### PR DESCRIPTION
# Add GPT-5.1 model support to OpenAI provider

## Summary
Added support for OpenAI's GPT-5.1 model to the gateway. This includes:
- New model definition file `gpt-5-1.openai.ts` following the existing GPT-5 pattern
- Model registration in the OpenAI provider's chat model factories
- Pricing configuration ($1.25/1M input tokens, $10.00/1M output tokens)
- Model specifications: 400K context window, 128K max output tokens

**Note**: Also updated the `jose` dependency in the vertex provider from ^5.2.0 to ^5.10.0 to fix a pre-existing test failure that was blocking commits.

## Review & Testing Checklist for Human
This PR has **HIGH RISK** and requires thorough testing:

- [x] **Verify GPT-5.1 is actually available in OpenAI's API** - The model may not be generally available yet or may require special access. Test with a real API call to confirm it works.
- [x] **Test end-to-end functionality** - Make actual API calls using the new model to ensure it works correctly with the gateway.
- [x] **Verify pricing accuracy** - Confirm the pricing ($1.25 input, $10.00 output per 1M tokens) matches OpenAI's current pricing.
- [x] **Check if GPT-5.1 requires different configuration** - The model has unique features (configurable reasoning effort, new tools like apply_patch/shell, unsupported parameters like temperature/top_p). The current implementation uses the same config as GPT-5, which may not be appropriate.
- [x] **Verify vertex provider still works** - The `jose` dependency update (^5.2.0 → ^5.10.0) was necessary to fix tests, but could have side effects. Run vertex provider tests to confirm.

### Test Plan
1. Try creating a chat completion with `gpt-5.1` model through the gateway
2. Verify the request succeeds and returns expected results
3. Check that pricing calculations are correct
4. Test with different configurations to ensure compatibility

### Notes
- GPT-5.1 documentation: https://platform.openai.com/docs/guides/latest-model
- The model definition follows the existing GPT-5 pattern but GPT-5.1 has unique features that may require special handling in the future
- Devin session: https://app.devin.ai/sessions/dedce58bf3f446ed8431a26d0b7adfa6
- Requested by: ankit@adaline.ai (@ankit-adaline)