### PR TITLE
feat: add Claude Opus 4.5 model (claude-opus-4-5-20251101)

### DIFF
--- a/core/providers/anthropic/src/models/chat-models/claude-opus-4-5-20251101.anthropic.ts
+++ b/core/providers/anthropic/src/models/chat-models/claude-opus-4-5-20251101.anthropic.ts
@@ -1,0 +1,48 @@
+import { z } from "zod";
+
+import { ChatModelSchema } from "@adaline/provider";
+
+import { AnthropicChatModelConfigs } from "../../configs";
+import pricingData from "../pricing.json";
+import { BaseChatModel, BaseChatModelOptions } from "./base-chat-model.anthropic";
+import {
+  AnthropicChatModelRoles,
+  AnthropicChatModelRolesMap,
+  AnthropicThinkingChatModelModalities,
+  AnthropicThinkingChatModelModalitiesEnum,
+} from "./types";
+
+const ClaudeOpus4_520251101Literal = "claude-opus-4-5-20251101";
+const ClaudeOpus4_520251101Description = "Premium model combining maximum intelligence with practical performance. Ideal for complex specialized tasks, professional software engineering, and advanced agents. Training cutoff: August 2025.";
+
+const ClaudeOpus4_520251101Schema = ChatModelSchema(AnthropicChatModelRoles, AnthropicThinkingChatModelModalitiesEnum).parse({
+  name: ClaudeOpus4_520251101Literal,
+  description: ClaudeOpus4_520251101Description,
+  maxInputTokens: 200000,
+  maxOutputTokens: 64000,
+  maxReasoningTokens: 64000,
+  roles: AnthropicChatModelRolesMap,
+  modalities: AnthropicThinkingChatModelModalities,
+  config: {
+    def: AnthropicChatModelConfigs.extendedThinking(64000, 4, 1024, 64000).def,
+    schema: AnthropicChatModelConfigs.extendedThinking(64000, 4, 1024, 64000).schema,
+  },
+  price: pricingData[ClaudeOpus4_520251101Literal],
+});
+
+const ClaudeOpus4_520251101Options = BaseChatModelOptions;
+type ClaudeOpus4_520251101OptionsType = z.infer<typeof ClaudeOpus4_520251101Options>;
+
+class ClaudeOpus4_520251101 extends BaseChatModel {
+  constructor(options: ClaudeOpus4_520251101OptionsType) {
+    super(ClaudeOpus4_520251101Schema, options);
+  }
+}
+
+export {
+  ClaudeOpus4_520251101,
+  ClaudeOpus4_520251101Literal,
+  ClaudeOpus4_520251101Options,
+  ClaudeOpus4_520251101Schema,
+  type ClaudeOpus4_520251101OptionsType,
+};

--- a/core/providers/anthropic/src/models/chat-models/index.ts
+++ b/core/providers/anthropic/src/models/chat-models/index.ts
@@ -1,6 +1,7 @@
 export * from "./base-chat-model.anthropic";
 export * from "./claude-4-opus-20250514.anthropic";
 export * from "./claude-4-sonnet-20250514.anthropic";
+export * from "./claude-opus-4-5-20251101.anthropic";
 export * from "./claude-sonnet-4-5-20250929.anthropic";
 export * from "./claude-3-5-sonnet-20240620.anthropic";
 export * from "./claude-3-5-sonnet-20241022.anthropic";

--- a/core/providers/anthropic/src/models/pricing.json
+++ b/core/providers/anthropic/src/models/pricing.json
@@ -174,5 +174,21 @@
         }
       }
     ]
+  },
+  "claude-opus-4-5-20251101": {
+    "modelName": "claude-opus-4-5-20251101",
+    "currency": "USD",
+    "tokenRanges": [
+      {
+        "minTokens": 0,
+        "maxTokens": null,
+        "prices": {
+          "base": {
+            "inputPricePerMillion": 5,
+            "outputPricePerMillion": 25
+          }
+        }
+      }
+    ]
   }
 }

--- a/core/providers/anthropic/src/provider/provider.anthropic.ts
+++ b/core/providers/anthropic/src/provider/provider.anthropic.ts
@@ -69,6 +69,11 @@ class Anthropic<C extends Models.BaseChatModelOptionsType, E extends Models.Base
       modelOptions: Models.Claude4Opus20250514Options,
       modelSchema: Models.Claude4Opus20250514Schema,
     },
+    [Models.ClaudeOpus4_520251101Literal]: {
+      model: Models.ClaudeOpus4_520251101,
+      modelOptions: Models.ClaudeOpus4_520251101Options,
+      modelSchema: Models.ClaudeOpus4_520251101Schema,
+    },
   };
 
   private readonly embeddingModelFactories: Record<

--- a/core/providers/bedrock/src/models/chat-models/anthropic/claude-opus-4-5-20251101.anthropic.bedrock.ts
+++ b/core/providers/bedrock/src/models/chat-models/anthropic/claude-opus-4-5-20251101.anthropic.bedrock.ts
@@ -1,0 +1,48 @@
+import { z } from "zod";
+
+import {
+  AnthropicChatModelModalities,
+  AnthropicChatModelModalitiesEnum,
+  AnthropicChatModelRoles,
+  AnthropicChatModelRolesMap,
+} from "@adaline/anthropic";
+import { ChatModelSchema } from "@adaline/provider";
+
+import { BedrockAnthropicChatModelConfigs } from "../../../configs";
+import { BaseChatModelOptions } from "../base-chat-model-options.bedrock";
+import pricingData from "./../../pricing.json";
+import { BaseChatModelAnthropic } from "./base-chat-model.anthropic.bedrock";
+
+const BedrockClaudeOpus4_520251101Literal = "anthropic.claude-opus-4-5-20251101-v1:0";
+const BedrockClaudeOpus4_520251101Description = "Premium model combining maximum intelligence with practical performance. Ideal for complex specialized tasks, professional software engineering, and advanced agents. Training cutoff: August 2025.";
+
+const BedrockClaudeOpus4_520251101Schema = ChatModelSchema(AnthropicChatModelRoles, AnthropicChatModelModalitiesEnum).parse({
+  name: BedrockClaudeOpus4_520251101Literal,
+  description: BedrockClaudeOpus4_520251101Description,
+  maxInputTokens: 200000,
+  maxOutputTokens: 64000,
+  roles: AnthropicChatModelRolesMap,
+  modalities: AnthropicChatModelModalities,
+  config: {
+    def: BedrockAnthropicChatModelConfigs.base(64000, 4).def,
+    schema: BedrockAnthropicChatModelConfigs.base(64000, 4).schema,
+  },
+  price: pricingData[BedrockClaudeOpus4_520251101Literal],
+});
+
+const BedrockClaudeOpus4_520251101Options = BaseChatModelOptions;
+type BedrockClaudeOpus4_520251101OptionsType = z.infer<typeof BedrockClaudeOpus4_520251101Options>;
+
+class BedrockClaudeOpus4_520251101 extends BaseChatModelAnthropic {
+  constructor(options: BedrockClaudeOpus4_520251101OptionsType) {
+    super(BedrockClaudeOpus4_520251101Schema, options);
+  }
+}
+
+export {
+  BedrockClaudeOpus4_520251101,
+  BedrockClaudeOpus4_520251101Literal,
+  BedrockClaudeOpus4_520251101Options,
+  BedrockClaudeOpus4_520251101Schema,
+  type BedrockClaudeOpus4_520251101OptionsType,
+};

--- a/core/providers/bedrock/src/models/chat-models/anthropic/index.ts
+++ b/core/providers/bedrock/src/models/chat-models/anthropic/index.ts
@@ -8,4 +8,5 @@ export * from "./claude-3-opus-20240229.anthropic.bedrock";
 export * from "./claude-3-sonnet-20240229.anthropic.bedrock";
 export * from "./claude-4-opus-20250514.anthropic.bedrock";
 export * from "./claude-4-sonnet-20250514.anthropic.bedrock";
+export * from "./claude-opus-4-5-20251101.anthropic.bedrock";
 export * from "./claude-sonnet-4-5-20250929.anthropic.bedrock";

--- a/core/providers/bedrock/src/models/pricing.json
+++ b/core/providers/bedrock/src/models/pricing.json
@@ -158,5 +158,21 @@
         }
       }
     ]
+  },
+  "anthropic.claude-opus-4-5-20251101-v1:0": {
+    "modelName": "anthropic.claude-opus-4-5-20251101-v1:0",
+    "currency": "USD",
+    "tokenRanges": [
+      {
+        "minTokens": 0,
+        "maxTokens": null,
+        "prices": {
+          "base": {
+            "inputPricePerMillion": 5,
+            "outputPricePerMillion": 25
+          }
+        }
+      }
+    ]
   }
 }

--- a/core/providers/bedrock/src/provider/provider.bedrock.ts
+++ b/core/providers/bedrock/src/provider/provider.bedrock.ts
@@ -70,6 +70,11 @@ class Bedrock<C extends Models.BaseChatModelOptionsType, E extends Record<string
       modelOptions: Models.BedrockClaude4Opus20250514Options,
       modelSchema: Models.BedrockClaude4Opus20250514Schema,
     },
+    [Models.BedrockClaudeOpus4_520251101Literal]: {
+      model: Models.BedrockClaudeOpus4_520251101,
+      modelOptions: Models.BedrockClaudeOpus4_520251101Options,
+      modelSchema: Models.BedrockClaudeOpus4_520251101Schema,
+    },
   };
 
   private readonly embeddingModelFactories: Record<


### PR DESCRIPTION
## Summary

Adds support for the new Claude Opus 4.5 model (released November 24, 2025) to the Anthropic and Bedrock providers.

**Anthropic provider:**
- Model name: `claude-opus-4-5-20251101`
- Extended thinking support enabled (64K reasoning tokens)

**Bedrock provider:**
- Model name: `anthropic.claude-opus-4-5-20251101-v1:0`
- Base config (no extended thinking, following existing Bedrock patterns)

**Specifications:**
- Context window: 200K tokens
- Max output: 64K tokens
- Pricing: $5/M input, $25/M output

## Review & Testing Checklist for Human

- [ ] **Verify model names** match official Anthropic documentation exactly - incorrect names will cause API failures
- [ ] **Verify pricing** ($5 input, $25 output per million tokens) against https://www.anthropic.com/pricing
- [ ] **Verify token limits** (200K context, 64K output) against https://platform.claude.com/docs/en/about-claude/models/whats-new-claude-4-5
- [ ] **Test API call** with the new model to confirm it works end-to-end

**Recommended test plan:** Make a simple chat completion request using `claude-opus-4-5-20251101` through the Gateway to verify the model is recognized and the API responds correctly.

### Notes

- Vertex provider was not updated as it only contains Google Gemini models in this codebase
- CI may show failures in the Vertex provider tests due to a pre-existing issue (missing `jose` package) - this is unrelated to these changes
- Followed the implementation pattern of `claude-sonnet-4-5-20250929` for Anthropic and Bedrock

Link to Devin run: https://app.devin.ai/sessions/2d8530cbf6bd4907938a22a04a6cdde1
Requested by: Akshay (akshay@adaline.ai) / @adaline-akshay