### PR TITLE
fix(types): preserve JSON Schema keywords in responseSchema

### DIFF
--- a/core/providers/openai/tests/models/chat-models/base-chat-model.openai.test.ts
+++ b/core/providers/openai/tests/models/chat-models/base-chat-model.openai.test.ts
@@ -561,10 +561,11 @@ describe("BaseChatModel", () => {
       });
     });
 
-    it("should preserve nested JSON Schema keywords in response schema", () => {
+    it("should preserve responseSchema for strict json_schema mode", () => {
       const responseSchema = {
         name: "Envelope",
         description: "Schema with nested JSON Schema keywords",
+        strict: true,
         schema: {
           type: "object",
           required: ["payload"],
@@ -613,11 +614,10 @@ describe("BaseChatModel", () => {
       });
 
       const result = gpt5Model.transformConfig(config, [], []);
-      const transformedSchema = (result.response_format as any).json_schema.schema;
-
-      expect(transformedSchema.properties.payload.additionalProperties).toBe(false);
-      expect(transformedSchema.properties.payload.$defs).toEqual(responseSchema.schema.properties.payload.$defs);
-      expect(transformedSchema.properties.payload.properties.entity.$ref).toBe("#/$defs/userEntity");
+      expect(result.response_format).toEqual({
+        type: "json_schema",
+        json_schema: responseSchema,
+      });
     });
 
     it("should handle all valid response format values", () => {

--- a/packages/types/src/config/response-schema.config.ts
+++ b/packages/types/src/config/response-schema.config.ts
@@ -5,33 +5,37 @@ const ResponseSchemaTypes = ["object", "array", "number", "string", "boolean", "
 const ResponseSchemaTypesLiteral = z.enum(ResponseSchemaTypes);
 type ResponseSchemaTypesType = z.infer<typeof ResponseSchemaTypesLiteral>;
 
-const ResponseSchemaProperty = z.object({
-  anyOf: z.array(z.any()).optional(),
-  type: z.union([ResponseSchemaTypesLiteral, z.array(z.union([ResponseSchemaTypesLiteral, z.literal("null")]))]).optional(),
-  default: z.any().optional(),
-  title: z.string().optional(),
-  description: z.string().max(4096).optional(),
-  properties: z.record(z.any()).optional(),
-  required: z.array(z.string()).optional(),
-  minItems: z.number().int().min(0).optional(),
-  maxItems: z.number().int().optional(),
-  items: z.record(z.any()).optional(), // Recursive structure to handle nested arrays and objects
-  enum: z.array(z.union([z.string(), z.number(), z.boolean(), z.null()])).optional(), // Enum for allowed values
-  minimum: z.number().optional(), // Minimum value for number
-  maximum: z.number().optional(), // Maximum value for number
-  minLength: z.number().int().min(0).optional(), // Minimum length for string
-  maxLength: z.number().int().optional(), // Maximum length for string
-  $ref: z.string().optional(), // Reference to another schema
-});
+const ResponseSchemaProperty = z
+  .object({
+    anyOf: z.array(z.any()).optional(),
+    type: z.union([ResponseSchemaTypesLiteral, z.array(z.union([ResponseSchemaTypesLiteral, z.literal("null")]))]).optional(),
+    default: z.any().optional(),
+    title: z.string().optional(),
+    description: z.string().max(4096).optional(),
+    properties: z.record(z.any()).optional(),
+    required: z.array(z.string()).optional(),
+    minItems: z.number().int().min(0).optional(),
+    maxItems: z.number().int().optional(),
+    items: z.record(z.any()).optional(), // Recursive structure to handle nested arrays and objects
+    enum: z.array(z.union([z.string(), z.number(), z.boolean(), z.null()])).optional(), // Enum for allowed values
+    minimum: z.number().optional(), // Minimum value for number
+    maximum: z.number().optional(), // Maximum value for number
+    minLength: z.number().int().min(0).optional(), // Minimum length for string
+    maxLength: z.number().int().optional(), // Maximum length for string
+    $ref: z.string().optional(), // Reference to another schema
+  })
+  .passthrough();
 type ResponseSchemaPropertyType = z.infer<typeof ResponseSchemaProperty>;
 
-const ResponseSchemaStructure = z.object({
-  type: z.enum(["object"]),
-  required: z.array(z.string()),
-  $defs: z.record(z.any()).optional(),
-  properties: z.record(ResponseSchemaProperty),
-  additionalProperties: z.literal(false),
-});
+const ResponseSchemaStructure = z
+  .object({
+    type: z.enum(["object"]),
+    required: z.array(z.string()),
+    $defs: z.record(z.any()).optional(),
+    properties: z.record(ResponseSchemaProperty),
+    additionalProperties: z.literal(false),
+  })
+  .passthrough();
 type ResponseSchemaStructureType = z.infer<typeof ResponseSchemaStructure>;
 
 const ResponseSchema = z


### PR DESCRIPTION
When chatComplete is called with responseSchema.strict = true, Adaline strips nested JSON Schema keys during parsing, so the forwarded schema is altered and strict structured fails.

## Summary
- preserve unknown JSON Schema keys in response schema validation by using non-destructive parsing
- add a regression test in OpenAI GPT-5 config transform to ensure nested `additionalProperties`, `$defs`, and `$ref` survive

## Root Cause
`ResponseSchemaProperty` and `ResponseSchemaStructure` used plain `z.object(...)`, which strips unknown keys by default. This removed valid JSON Schema keywords before request execution.

## Fix
- `packages/types/src/config/response-schema.config.ts`
  - `ResponseSchemaProperty`: add `.passthrough()`
  - `ResponseSchemaStructure`: add `.passthrough()`

## Validation
- `pnpm exec vitest run core/providers/openai/tests/models/chat-models/base-chat-model.openai.test.ts`
- pre-push hooks also ran full workspace build/test and passed
