### PR TITLE
docs: add Codex AGENTS instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,57 @@
+# AGENTS.md
+
+This repository ships the Adaline Gateway SDK: a local, typed TypeScript SDK for calling many LLM providers through one interface.
+
+## Stack
+
+- Node.js 18+
+- pnpm 9+ only
+- Turborepo
+- TypeScript + tsup
+- Vitest
+- ESLint + Prettier
+- Changesets for releases
+
+## Working Agreement
+
+- Use `pnpm`, never `npm` or `yarn`.
+- Prefer the smallest possible change in the relevant package instead of broad refactors.
+- Preserve dual-output package behavior: ESM, CJS, and type declarations.
+- Keep imports and exports aligned with existing package barrel patterns.
+- Do not hand-edit release artifacts or `.changeset` files unless the task is explicitly about release/versioning.
+- When changing provider behavior, review the matching provider package and shared contracts in `packages/types` and `packages/provider`.
+
+## Repository Map
+
+- `core/gateway/`: gateway orchestrator, plugins, handlers, errors
+- `core/providers/`: provider implementations
+- `packages/types/`: shared Zod schemas and inferred types
+- `packages/provider/`: base provider contracts
+- `tools/`: shared eslint and tsconfig packages
+
+## Commands
+
+- Install: `pnpm install`
+- Build all: `pnpm run build`
+- Test all: `pnpm run test`
+- Lint all: `pnpm run lint`
+- Format all: `pnpm run format`
+- Clean: `pnpm run clean`
+
+## Validation
+
+- For provider or shared type changes, run the narrowest package test/build that proves the change works.
+- Before finishing a non-trivial change, run at least `pnpm run lint` and the relevant `pnpm run test` scope.
+- If a change affects published behavior or package surfaces, mention whether a changeset is required.
+
+## Coding Rules
+
+- Use Zod schemas at runtime boundaries and export both schema and inferred type when the package already follows that pattern.
+- Prefer `unknown` plus validation over `any`.
+- Add or update tests for public API behavior, edge cases, and provider-specific error handling.
+- Mock external provider calls in tests. Do not hit live APIs from test code.
+
+## Nested Instructions
+
+- Read `core/providers/AGENTS.md` before editing any provider package.
+- Read `packages/types/AGENTS.md` before changing shared schemas or message/content types.

--- a/core/providers/AGENTS.md
+++ b/core/providers/AGENTS.md
@@ -10,7 +10,7 @@ These packages implement provider-specific model catalogs and request/response b
 
 ## Standard Layout
 
-- `src/configs/`: model config objects
+- `src/configs/`: model config objects (present in providers that define shared config schemas; omitted by some providers such as `azure` and `custom`)
 - `src/models/`: model schemas and model catalog exports
 - `src/provider/`: provider class implementation
 

--- a/core/providers/AGENTS.md
+++ b/core/providers/AGENTS.md
@@ -1,0 +1,28 @@
+# AGENTS.md
+
+These packages implement provider-specific model catalogs and request/response behavior.
+
+## Expectations
+
+- Follow an existing provider in this directory as the template before introducing a new pattern.
+- Keep provider changes self-contained unless a shared contract truly needs to move.
+- Preserve provider naming, file layout, and export conventions.
+
+## Standard Layout
+
+- `src/configs/`: model config objects
+- `src/models/`: model schemas and model catalog exports
+- `src/provider/`: provider class implementation
+
+## Change Rules
+
+- Add models by following the current provider's naming and barrel export patterns exactly.
+- Keep provider-specific validation close to the provider unless multiple providers truly share it.
+- Prefer explicit model metadata over clever indirection. This repo values clarity in model catalogs.
+- If a model family affects pricing, capability flags, or tool-calling behavior, verify all related config files are updated together.
+
+## Validation
+
+- Run the provider package build.
+- Run the provider package tests or the narrowest relevant Turbo/Vitest scope.
+- If shared types changed, also validate the affected shared package.

--- a/packages/types/AGENTS.md
+++ b/packages/types/AGENTS.md
@@ -1,0 +1,16 @@
+# AGENTS.md
+
+This package defines shared runtime schemas and types used across the gateway and providers.
+
+## Rules
+
+- Treat this package as a contract surface. Small edits can affect every provider.
+- Prefer additive changes over breaking structural changes.
+- Export both the Zod schema and the inferred TypeScript type when following an existing module pattern.
+- Keep naming consistent with adjacent message, content, config, and tool schema files.
+- Do not introduce `any`.
+
+## Validation
+
+- Run the local package build/test flow.
+- Validate at least one downstream package if the change modifies a widely used schema.


### PR DESCRIPTION
## Summary\n- add a root `AGENTS.md` for Codex with repo-level build, test, and package guidance\n- add nested `AGENTS.md` files for provider work and shared schema work\n- keep the instructions aligned with the repo's existing TypeScript, pnpm, Turbo, Vitest, and changeset conventions\n\n## Testing\n- git diff --check