### PR TITLE
feat(providers): latest embedding models — gemini-embedding-2 + voyage-4 family + gemini-embedding-001

### DIFF
--- a/core/providers/anthropic/src/models/embedding-models/index.ts
+++ b/core/providers/anthropic/src/models/embedding-models/index.ts
@@ -10,3 +10,7 @@ export * from "./voyage-3-large.anthropic";
 export * from "./voyage-3-5.anthropic";
 export * from "./voyage-3-5-lite.anthropic";
 export * from "./voyage-code-3.anthropic";
+export * from "./voyage-4-large.anthropic";
+export * from "./voyage-4.anthropic";
+export * from "./voyage-4-lite.anthropic";
+export * from "./voyage-4-nano.anthropic";

--- a/core/providers/anthropic/src/models/embedding-models/voyage-4-large.anthropic.ts
+++ b/core/providers/anthropic/src/models/embedding-models/voyage-4-large.anthropic.ts
@@ -1,0 +1,35 @@
+import { z } from "zod";
+
+import { EmbeddingModelSchema } from "@adaline/provider";
+
+import { AnthropicEmbeddingModelConfigs } from "../../configs";
+import embeddingPricingData from "../embedding-pricing.json";
+import { BaseEmbeddingModel, BaseEmbeddingModelOptions } from "./base-embedding-model.anthropic";
+import { AnthropicEmbeddingModelModalities, AnthropicEmbeddingModelModalitiesEnum } from "./types";
+
+const Voyage4LargeLiteral = "voyage-4-large";
+const Voyage4LargeDescription = "Highest-quality general-purpose and multilingual retrieval. 32K input tokens.";
+
+const Voyage4LargeSchema = EmbeddingModelSchema(AnthropicEmbeddingModelModalitiesEnum).parse({
+  name: Voyage4LargeLiteral,
+  description: Voyage4LargeDescription,
+  modalities: AnthropicEmbeddingModelModalities,
+  maxInputTokens: 32000,
+  maxOutputTokens: 32000,
+  config: {
+    def: AnthropicEmbeddingModelConfigs.flexible().def,
+    schema: AnthropicEmbeddingModelConfigs.flexible().schema,
+  },
+  price: embeddingPricingData[Voyage4LargeLiteral],
+});
+
+const Voyage4LargeOptions = BaseEmbeddingModelOptions;
+type Voyage4LargeOptionsType = z.infer<typeof Voyage4LargeOptions>;
+
+class Voyage4Large extends BaseEmbeddingModel {
+  constructor(options: Voyage4LargeOptionsType) {
+    super(Voyage4LargeSchema, options);
+  }
+}
+
+export { Voyage4Large, Voyage4LargeOptions, Voyage4LargeSchema, Voyage4LargeLiteral, type Voyage4LargeOptionsType };

--- a/core/providers/anthropic/src/models/embedding-models/voyage-4-lite.anthropic.ts
+++ b/core/providers/anthropic/src/models/embedding-models/voyage-4-lite.anthropic.ts
@@ -1,0 +1,35 @@
+import { z } from "zod";
+
+import { EmbeddingModelSchema } from "@adaline/provider";
+
+import { AnthropicEmbeddingModelConfigs } from "../../configs";
+import embeddingPricingData from "../embedding-pricing.json";
+import { BaseEmbeddingModel, BaseEmbeddingModelOptions } from "./base-embedding-model.anthropic";
+import { AnthropicEmbeddingModelModalities, AnthropicEmbeddingModelModalitiesEnum } from "./types";
+
+const Voyage4LiteLiteral = "voyage-4-lite";
+const Voyage4LiteDescription = "Lower-latency, lower-cost general-purpose retrieval. 32K input tokens.";
+
+const Voyage4LiteSchema = EmbeddingModelSchema(AnthropicEmbeddingModelModalitiesEnum).parse({
+  name: Voyage4LiteLiteral,
+  description: Voyage4LiteDescription,
+  modalities: AnthropicEmbeddingModelModalities,
+  maxInputTokens: 32000,
+  maxOutputTokens: 32000,
+  config: {
+    def: AnthropicEmbeddingModelConfigs.flexible().def,
+    schema: AnthropicEmbeddingModelConfigs.flexible().schema,
+  },
+  price: embeddingPricingData[Voyage4LiteLiteral],
+});
+
+const Voyage4LiteOptions = BaseEmbeddingModelOptions;
+type Voyage4LiteOptionsType = z.infer<typeof Voyage4LiteOptions>;
+
+class Voyage4Lite extends BaseEmbeddingModel {
+  constructor(options: Voyage4LiteOptionsType) {
+    super(Voyage4LiteSchema, options);
+  }
+}
+
+export { Voyage4Lite, Voyage4LiteOptions, Voyage4LiteSchema, Voyage4LiteLiteral, type Voyage4LiteOptionsType };

--- a/core/providers/anthropic/src/models/embedding-models/voyage-4-nano.anthropic.ts
+++ b/core/providers/anthropic/src/models/embedding-models/voyage-4-nano.anthropic.ts
@@ -1,0 +1,35 @@
+import { z } from "zod";
+
+import { EmbeddingModelSchema } from "@adaline/provider";
+
+import { AnthropicEmbeddingModelConfigs } from "../../configs";
+import embeddingPricingData from "../embedding-pricing.json";
+import { BaseEmbeddingModel, BaseEmbeddingModelOptions } from "./base-embedding-model.anthropic";
+import { AnthropicEmbeddingModelModalities, AnthropicEmbeddingModelModalitiesEnum } from "./types";
+
+const Voyage4NanoLiteral = "voyage-4-nano";
+const Voyage4NanoDescription = "Smallest, fastest Voyage embedding for edge / open-weight deployments. 32K input tokens.";
+
+const Voyage4NanoSchema = EmbeddingModelSchema(AnthropicEmbeddingModelModalitiesEnum).parse({
+  name: Voyage4NanoLiteral,
+  description: Voyage4NanoDescription,
+  modalities: AnthropicEmbeddingModelModalities,
+  maxInputTokens: 32000,
+  maxOutputTokens: 32000,
+  config: {
+    def: AnthropicEmbeddingModelConfigs.flexible().def,
+    schema: AnthropicEmbeddingModelConfigs.flexible().schema,
+  },
+  price: embeddingPricingData[Voyage4NanoLiteral],
+});
+
+const Voyage4NanoOptions = BaseEmbeddingModelOptions;
+type Voyage4NanoOptionsType = z.infer<typeof Voyage4NanoOptions>;
+
+class Voyage4Nano extends BaseEmbeddingModel {
+  constructor(options: Voyage4NanoOptionsType) {
+    super(Voyage4NanoSchema, options);
+  }
+}
+
+export { Voyage4Nano, Voyage4NanoOptions, Voyage4NanoSchema, Voyage4NanoLiteral, type Voyage4NanoOptionsType };

--- a/core/providers/anthropic/src/models/embedding-models/voyage-4.anthropic.ts
+++ b/core/providers/anthropic/src/models/embedding-models/voyage-4.anthropic.ts
@@ -1,0 +1,35 @@
+import { z } from "zod";
+
+import { EmbeddingModelSchema } from "@adaline/provider";
+
+import { AnthropicEmbeddingModelConfigs } from "../../configs";
+import embeddingPricingData from "../embedding-pricing.json";
+import { BaseEmbeddingModel, BaseEmbeddingModelOptions } from "./base-embedding-model.anthropic";
+import { AnthropicEmbeddingModelModalities, AnthropicEmbeddingModelModalitiesEnum } from "./types";
+
+const Voyage4Literal = "voyage-4";
+const Voyage4Description = "Best balance of quality and cost for general-purpose retrieval. 32K input tokens.";
+
+const Voyage4Schema = EmbeddingModelSchema(AnthropicEmbeddingModelModalitiesEnum).parse({
+  name: Voyage4Literal,
+  description: Voyage4Description,
+  modalities: AnthropicEmbeddingModelModalities,
+  maxInputTokens: 32000,
+  maxOutputTokens: 32000,
+  config: {
+    def: AnthropicEmbeddingModelConfigs.flexible().def,
+    schema: AnthropicEmbeddingModelConfigs.flexible().schema,
+  },
+  price: embeddingPricingData[Voyage4Literal],
+});
+
+const Voyage4Options = BaseEmbeddingModelOptions;
+type Voyage4OptionsType = z.infer<typeof Voyage4Options>;
+
+class Voyage4 extends BaseEmbeddingModel {
+  constructor(options: Voyage4OptionsType) {
+    super(Voyage4Schema, options);
+  }
+}
+
+export { Voyage4, Voyage4Options, Voyage4Schema, Voyage4Literal, type Voyage4OptionsType };

--- a/core/providers/anthropic/src/models/embedding-pricing.json
+++ b/core/providers/anthropic/src/models/embedding-pricing.json
@@ -48,5 +48,25 @@
     "modelName": "voyage-multilingual-2",
     "currency": "USD",
     "inputPricePerMillion": 0.12
+  },
+  "voyage-4-large": {
+    "modelName": "voyage-4-large",
+    "currency": "USD",
+    "inputPricePerMillion": 0.18
+  },
+  "voyage-4": {
+    "modelName": "voyage-4",
+    "currency": "USD",
+    "inputPricePerMillion": 0.06
+  },
+  "voyage-4-lite": {
+    "modelName": "voyage-4-lite",
+    "currency": "USD",
+    "inputPricePerMillion": 0.02
+  },
+  "voyage-4-nano": {
+    "modelName": "voyage-4-nano",
+    "currency": "USD",
+    "inputPricePerMillion": 0.01
   }
 }

--- a/core/providers/anthropic/src/provider/provider.anthropic.ts
+++ b/core/providers/anthropic/src/provider/provider.anthropic.ts
@@ -154,6 +154,26 @@ class Anthropic<C extends Models.BaseChatModelOptionsType, E extends Models.Base
       modelOptions: Models.VoyageCode3Options,
       modelSchema: Models.VoyageCode3Schema,
     },
+    [Models.Voyage4LargeLiteral]: {
+      model: Models.Voyage4Large,
+      modelOptions: Models.Voyage4LargeOptions,
+      modelSchema: Models.Voyage4LargeSchema,
+    },
+    [Models.Voyage4Literal]: {
+      model: Models.Voyage4,
+      modelOptions: Models.Voyage4Options,
+      modelSchema: Models.Voyage4Schema,
+    },
+    [Models.Voyage4LiteLiteral]: {
+      model: Models.Voyage4Lite,
+      modelOptions: Models.Voyage4LiteOptions,
+      modelSchema: Models.Voyage4LiteSchema,
+    },
+    [Models.Voyage4NanoLiteral]: {
+      model: Models.Voyage4Nano,
+      modelOptions: Models.Voyage4NanoOptions,
+      modelSchema: Models.Voyage4NanoSchema,
+    },
   };
 
   chatModelLiterals(): string[] {

--- a/core/providers/google/src/models/embedding-models/gemini-embedding-001.google.ts
+++ b/core/providers/google/src/models/embedding-models/gemini-embedding-001.google.ts
@@ -1,0 +1,43 @@
+import { z } from "zod";
+
+import { EmbeddingModelSchema } from "@adaline/provider";
+
+import { GoogleEmbeddingModelConfigs } from "../../configs";
+import embeddingPricingData from "../embedding-pricing.json";
+import { BaseEmbeddingModel, BaseEmbeddingModelOptions } from "./base-embedding-model.google";
+import { GoogleEmbeddingModelModalities, GoogleEmbeddingModelModalitiesEnum } from "./types";
+
+const Gemini_Embedding_001Literal = "gemini-embedding-001";
+const Gemini_Embedding_001_Description =
+  "Gemini embedding model — Matryoshka representation learning. Default 3072 dimensions; " +
+  "recommended sizes 768 / 1536 / 3072 via `outputDimensionality`. Max input 2048 tokens.";
+
+const Gemini_Embedding_001Schema = EmbeddingModelSchema(GoogleEmbeddingModelModalitiesEnum).parse({
+  name: Gemini_Embedding_001Literal,
+  description: Gemini_Embedding_001_Description,
+  modalities: GoogleEmbeddingModelModalities,
+  maxInputTokens: 2048,
+  maxOutputTokens: 3072,
+  config: {
+    def: GoogleEmbeddingModelConfigs.base(3072).def,
+    schema: GoogleEmbeddingModelConfigs.base(3072).schema,
+  },
+  price: embeddingPricingData[Gemini_Embedding_001Literal],
+});
+
+const Gemini_Embedding_001Options = BaseEmbeddingModelOptions;
+type Gemini_Embedding_001OptionsType = z.infer<typeof Gemini_Embedding_001Options>;
+
+class Gemini_Embedding_001 extends BaseEmbeddingModel {
+  constructor(options: Gemini_Embedding_001OptionsType) {
+    super(Gemini_Embedding_001Schema, options);
+  }
+}
+
+export {
+  Gemini_Embedding_001,
+  Gemini_Embedding_001Options,
+  Gemini_Embedding_001Schema,
+  Gemini_Embedding_001Literal,
+  type Gemini_Embedding_001OptionsType,
+};

--- a/core/providers/google/src/models/embedding-models/gemini-embedding-2.google.ts
+++ b/core/providers/google/src/models/embedding-models/gemini-embedding-2.google.ts
@@ -1,0 +1,45 @@
+import { z } from "zod";
+
+import { EmbeddingModelSchema } from "@adaline/provider";
+
+import { GoogleEmbeddingModelConfigs } from "../../configs";
+import embeddingPricingData from "../embedding-pricing.json";
+import { BaseEmbeddingModel, BaseEmbeddingModelOptions } from "./base-embedding-model.google";
+import { GoogleEmbeddingModelModalities, GoogleEmbeddingModelModalitiesEnum } from "./types";
+
+const Gemini_Embedding_2Literal = "gemini-embedding-2";
+const Gemini_Embedding_2_Description =
+  "Gemini Embedding 2 — Matryoshka representation learning with extended context. Default 3072 " +
+  "dimensions; recommended sizes 768 / 1536 / 3072 via `outputDimensionality`. Max input 8192 " +
+  "tokens (4× gemini-embedding-001). Successor to gemini-embedding-001 with multimodal support " +
+  "available via the Gemini API (text-only path used here).";
+
+const Gemini_Embedding_2Schema = EmbeddingModelSchema(GoogleEmbeddingModelModalitiesEnum).parse({
+  name: Gemini_Embedding_2Literal,
+  description: Gemini_Embedding_2_Description,
+  modalities: GoogleEmbeddingModelModalities,
+  maxInputTokens: 8192,
+  maxOutputTokens: 3072,
+  config: {
+    def: GoogleEmbeddingModelConfigs.base(3072).def,
+    schema: GoogleEmbeddingModelConfigs.base(3072).schema,
+  },
+  price: embeddingPricingData[Gemini_Embedding_2Literal],
+});
+
+const Gemini_Embedding_2Options = BaseEmbeddingModelOptions;
+type Gemini_Embedding_2OptionsType = z.infer<typeof Gemini_Embedding_2Options>;
+
+class Gemini_Embedding_2 extends BaseEmbeddingModel {
+  constructor(options: Gemini_Embedding_2OptionsType) {
+    super(Gemini_Embedding_2Schema, options);
+  }
+}
+
+export {
+  Gemini_Embedding_2,
+  Gemini_Embedding_2Options,
+  Gemini_Embedding_2Schema,
+  Gemini_Embedding_2Literal,
+  type Gemini_Embedding_2OptionsType,
+};

--- a/core/providers/google/src/models/embedding-models/index.ts
+++ b/core/providers/google/src/models/embedding-models/index.ts
@@ -3,3 +3,4 @@ export * from "./base-embedding-model.google";
 export * from "./text-embedding-001.google";
 export * from "./text-embedding-004.google";
 export * from "./gemini-embedding-001.google";
+export * from "./gemini-embedding-2.google";

--- a/core/providers/google/src/models/embedding-models/index.ts
+++ b/core/providers/google/src/models/embedding-models/index.ts
@@ -2,3 +2,4 @@ export * from "./types";
 export * from "./base-embedding-model.google";
 export * from "./text-embedding-001.google";
 export * from "./text-embedding-004.google";
+export * from "./gemini-embedding-001.google";

--- a/core/providers/google/src/models/embedding-pricing.json
+++ b/core/providers/google/src/models/embedding-pricing.json
@@ -8,5 +8,10 @@
     "modelName": "text-embedding-004",
     "currency": "USD",
     "inputPricePerMillion": 0
+  },
+  "gemini-embedding-001": {
+    "modelName": "gemini-embedding-001",
+    "currency": "USD",
+    "inputPricePerMillion": 0.15
   }
 }

--- a/core/providers/google/src/models/embedding-pricing.json
+++ b/core/providers/google/src/models/embedding-pricing.json
@@ -13,5 +13,10 @@
     "modelName": "gemini-embedding-001",
     "currency": "USD",
     "inputPricePerMillion": 0.15
+  },
+  "gemini-embedding-2": {
+    "modelName": "gemini-embedding-2",
+    "currency": "USD",
+    "inputPricePerMillion": 0.15
   }
 }

--- a/core/providers/google/src/provider/provider.google.ts
+++ b/core/providers/google/src/provider/provider.google.ts
@@ -151,6 +151,11 @@ class Google<C extends Models.BaseChatModelOptionsType, E extends Models.BaseEmb
       modelOptions: Models.Gemini_Embedding_001Options,
       modelSchema: Models.Gemini_Embedding_001Schema,
     },
+    [Models.Gemini_Embedding_2Literal]: {
+      model: Models.Gemini_Embedding_2,
+      modelOptions: Models.Gemini_Embedding_2Options,
+      modelSchema: Models.Gemini_Embedding_2Schema,
+    },
   };
 
   chatModelLiterals(): string[] {

--- a/core/providers/google/src/provider/provider.google.ts
+++ b/core/providers/google/src/provider/provider.google.ts
@@ -146,6 +146,11 @@ class Google<C extends Models.BaseChatModelOptionsType, E extends Models.BaseEmb
       modelOptions: Models.Text_Embedding_004Options,
       modelSchema: Models.Text_Embedding_004Schema,
     },
+    [Models.Gemini_Embedding_001Literal]: {
+      model: Models.Gemini_Embedding_001,
+      modelOptions: Models.Gemini_Embedding_001Options,
+      modelSchema: Models.Gemini_Embedding_001Schema,
+    },
   };
 
   chatModelLiterals(): string[] {

--- a/core/providers/vertex/src/models/embedding-models/gemini-embedding-001.vertex.ts
+++ b/core/providers/vertex/src/models/embedding-models/gemini-embedding-001.vertex.ts
@@ -1,0 +1,43 @@
+import { z } from "zod";
+
+import { EmbeddingModelSchema } from "@adaline/provider";
+
+import { VertexEmbeddingModelConfigs } from "../../configs";
+import embeddingPricingData from "../embedding-pricing.json";
+import { BaseEmbeddingModel, BaseEmbeddingModelOptions } from "./base-embedding-model.vertex";
+import { VertexEmbeddingModelModalities, VertexEmbeddingModelModalitiesEnum } from "./types";
+
+const Gemini_Embedding_001Literal = "gemini-embedding-001";
+const Gemini_Embedding_001_Description =
+  "Gemini embedding model on Vertex AI — Matryoshka representation learning. Default 3072 " +
+  "dimensions; recommended sizes 768 / 1536 / 3072 via `outputDimensionality`. Max input 2048 tokens.";
+
+const Gemini_Embedding_001Schema = EmbeddingModelSchema(VertexEmbeddingModelModalitiesEnum).parse({
+  name: Gemini_Embedding_001Literal,
+  description: Gemini_Embedding_001_Description,
+  modalities: VertexEmbeddingModelModalities,
+  maxInputTokens: 2048,
+  maxOutputTokens: 3072,
+  config: {
+    def: VertexEmbeddingModelConfigs.base(3072).def,
+    schema: VertexEmbeddingModelConfigs.base(3072).schema,
+  },
+  price: embeddingPricingData[Gemini_Embedding_001Literal],
+});
+
+const Gemini_Embedding_001Options = BaseEmbeddingModelOptions;
+type Gemini_Embedding_001OptionsType = z.infer<typeof Gemini_Embedding_001Options>;
+
+class Gemini_Embedding_001 extends BaseEmbeddingModel {
+  constructor(options: Gemini_Embedding_001OptionsType) {
+    super(Gemini_Embedding_001Schema, options);
+  }
+}
+
+export {
+  Gemini_Embedding_001,
+  Gemini_Embedding_001Options,
+  Gemini_Embedding_001Schema,
+  Gemini_Embedding_001Literal,
+  type Gemini_Embedding_001OptionsType,
+};

--- a/core/providers/vertex/src/models/embedding-models/gemini-embedding-2.vertex.ts
+++ b/core/providers/vertex/src/models/embedding-models/gemini-embedding-2.vertex.ts
@@ -1,0 +1,45 @@
+import { z } from "zod";
+
+import { EmbeddingModelSchema } from "@adaline/provider";
+
+import { VertexEmbeddingModelConfigs } from "../../configs";
+import embeddingPricingData from "../embedding-pricing.json";
+import { BaseEmbeddingModel, BaseEmbeddingModelOptions } from "./base-embedding-model.vertex";
+import { VertexEmbeddingModelModalities, VertexEmbeddingModelModalitiesEnum } from "./types";
+
+const Gemini_Embedding_2Literal = "gemini-embedding-2";
+const Gemini_Embedding_2_Description =
+  "Gemini Embedding 2 on Vertex AI — Matryoshka representation learning with extended context. " +
+  "Default 3072 dimensions; recommended sizes 768 / 1536 / 3072 via `outputDimensionality`. Max " +
+  "input 8192 tokens (4× gemini-embedding-001). Successor to gemini-embedding-001 with " +
+  "multimodal support available via the Vertex API (text-only path used here).";
+
+const Gemini_Embedding_2Schema = EmbeddingModelSchema(VertexEmbeddingModelModalitiesEnum).parse({
+  name: Gemini_Embedding_2Literal,
+  description: Gemini_Embedding_2_Description,
+  modalities: VertexEmbeddingModelModalities,
+  maxInputTokens: 8192,
+  maxOutputTokens: 3072,
+  config: {
+    def: VertexEmbeddingModelConfigs.base(3072).def,
+    schema: VertexEmbeddingModelConfigs.base(3072).schema,
+  },
+  price: embeddingPricingData[Gemini_Embedding_2Literal],
+});
+
+const Gemini_Embedding_2Options = BaseEmbeddingModelOptions;
+type Gemini_Embedding_2OptionsType = z.infer<typeof Gemini_Embedding_2Options>;
+
+class Gemini_Embedding_2 extends BaseEmbeddingModel {
+  constructor(options: Gemini_Embedding_2OptionsType) {
+    super(Gemini_Embedding_2Schema, options);
+  }
+}
+
+export {
+  Gemini_Embedding_2,
+  Gemini_Embedding_2Options,
+  Gemini_Embedding_2Schema,
+  Gemini_Embedding_2Literal,
+  type Gemini_Embedding_2OptionsType,
+};

--- a/core/providers/vertex/src/models/embedding-models/index.ts
+++ b/core/providers/vertex/src/models/embedding-models/index.ts
@@ -1,5 +1,6 @@
 export * from "./base-embedding-model.vertex";
 export * from "./text-embedding-004.vertex";
+export * from "./text-embedding-005.vertex";
 export * from "./text-multilingual-embedding-002.vertex";
 export * from "./textembedding-gecko-multilingual-001.vertex";
 export * from "./textembedding-gecko-003.vertex";

--- a/core/providers/vertex/src/models/embedding-models/index.ts
+++ b/core/providers/vertex/src/models/embedding-models/index.ts
@@ -5,3 +5,4 @@ export * from "./text-multilingual-embedding-002.vertex";
 export * from "./textembedding-gecko-multilingual-001.vertex";
 export * from "./textembedding-gecko-003.vertex";
 export * from "./gemini-embedding-001.vertex";
+export * from "./gemini-embedding-2.vertex";

--- a/core/providers/vertex/src/models/embedding-models/index.ts
+++ b/core/providers/vertex/src/models/embedding-models/index.ts
@@ -3,3 +3,4 @@ export * from "./text-embedding-004.vertex";
 export * from "./text-multilingual-embedding-002.vertex";
 export * from "./textembedding-gecko-multilingual-001.vertex";
 export * from "./textembedding-gecko-003.vertex";
+export * from "./gemini-embedding-001.vertex";

--- a/core/providers/vertex/src/models/embedding-models/text-embedding-005.vertex.ts
+++ b/core/providers/vertex/src/models/embedding-models/text-embedding-005.vertex.ts
@@ -1,0 +1,43 @@
+import { z } from "zod";
+
+import { EmbeddingModelSchema } from "@adaline/provider";
+
+import { VertexEmbeddingModelConfigs } from "../../configs";
+import embeddingPricingData from "../embedding-pricing.json";
+import { BaseEmbeddingModel, BaseEmbeddingModelOptions } from "./base-embedding-model.vertex";
+import { VertexEmbeddingModelModalities, VertexEmbeddingModelModalitiesEnum } from "./types";
+
+const Text_Embedding_005Literal = "text-embedding-005";
+const Text_Embedding_005_Description =
+  "Vertex AI text-embedding-005 — English-only general-purpose text embedding, default 768 dims, " +
+  "configurable via `outputDimensionality`. Drop-in successor to text-embedding-004.";
+
+const Text_Embedding_005Schema = EmbeddingModelSchema(VertexEmbeddingModelModalitiesEnum).parse({
+  name: Text_Embedding_005Literal,
+  description: Text_Embedding_005_Description,
+  modalities: VertexEmbeddingModelModalities,
+  maxInputTokens: 2048,
+  maxOutputTokens: 768,
+  config: {
+    def: VertexEmbeddingModelConfigs.base(768).def,
+    schema: VertexEmbeddingModelConfigs.base(768).schema,
+  },
+  price: embeddingPricingData[Text_Embedding_005Literal],
+});
+
+const Text_Embedding_005Options = BaseEmbeddingModelOptions;
+type Text_Embedding_005OptionsType = z.infer<typeof Text_Embedding_005Options>;
+
+class Text_Embedding_005 extends BaseEmbeddingModel {
+  constructor(options: Text_Embedding_005OptionsType) {
+    super(Text_Embedding_005Schema, options);
+  }
+}
+
+export {
+  Text_Embedding_005,
+  Text_Embedding_005Options,
+  Text_Embedding_005Schema,
+  Text_Embedding_005Literal,
+  type Text_Embedding_005OptionsType,
+};

--- a/core/providers/vertex/src/models/embedding-pricing.json
+++ b/core/providers/vertex/src/models/embedding-pricing.json
@@ -18,5 +18,10 @@
     "modelName": "textembedding-gecko-multilingual@001",
     "currency": "USD",
     "inputPricePerMillion": 0.1
+  },
+  "gemini-embedding-001": {
+    "modelName": "gemini-embedding-001",
+    "currency": "USD",
+    "inputPricePerMillion": 0.15
   }
 }

--- a/core/providers/vertex/src/models/embedding-pricing.json
+++ b/core/providers/vertex/src/models/embedding-pricing.json
@@ -28,5 +28,10 @@
     "modelName": "gemini-embedding-001",
     "currency": "USD",
     "inputPricePerMillion": 0.15
+  },
+  "gemini-embedding-2": {
+    "modelName": "gemini-embedding-2",
+    "currency": "USD",
+    "inputPricePerMillion": 0.15
   }
 }

--- a/core/providers/vertex/src/models/embedding-pricing.json
+++ b/core/providers/vertex/src/models/embedding-pricing.json
@@ -19,6 +19,11 @@
     "currency": "USD",
     "inputPricePerMillion": 0.1
   },
+  "text-embedding-005": {
+    "modelName": "text-embedding-005",
+    "currency": "USD",
+    "inputPricePerMillion": 0.1
+  },
   "gemini-embedding-001": {
     "modelName": "gemini-embedding-001",
     "currency": "USD",

--- a/core/providers/vertex/src/provider/provider.vertex.ts
+++ b/core/providers/vertex/src/provider/provider.vertex.ts
@@ -155,6 +155,16 @@ class Vertex<C extends Models.BaseChatModelOptionsType, E extends Models.BaseEmb
       modelOptions: Models.Text_Embedding_Gecko_Multilingual_001Options,
       modelSchema: Models.Text_Embedding_Gecko_Multilingual_001Schema,
     },
+    [Models.Text_Embedding_005Literal]: {
+      model: Models.Text_Embedding_005,
+      modelOptions: Models.Text_Embedding_005Options,
+      modelSchema: Models.Text_Embedding_005Schema,
+    },
+    [Models.Gemini_Embedding_001Literal]: {
+      model: Models.Gemini_Embedding_001,
+      modelOptions: Models.Gemini_Embedding_001Options,
+      modelSchema: Models.Gemini_Embedding_001Schema,
+    },
   };
 
   chatModelLiterals(): string[] {

--- a/core/providers/vertex/src/provider/provider.vertex.ts
+++ b/core/providers/vertex/src/provider/provider.vertex.ts
@@ -165,6 +165,11 @@ class Vertex<C extends Models.BaseChatModelOptionsType, E extends Models.BaseEmb
       modelOptions: Models.Gemini_Embedding_001Options,
       modelSchema: Models.Gemini_Embedding_001Schema,
     },
+    [Models.Gemini_Embedding_2Literal]: {
+      model: Models.Gemini_Embedding_2,
+      modelOptions: Models.Gemini_Embedding_2Options,
+      modelSchema: Models.Gemini_Embedding_2Schema,
+    },
   };
 
   chatModelLiterals(): string[] {


### PR DESCRIPTION
## Summary

Brings the gateway's embedding catalog up to date with **7 new models** verified against official Google + Voyage docs as of 2025-2026.

| Provider | Models added |
|---|---|
| **google** (Generative Language API) | gemini-embedding-001, **gemini-embedding-2** |
| **vertex** (Vertex AI) | text-embedding-005, gemini-embedding-001, **gemini-embedding-2** |
| **anthropic** (Voyage) | **voyage-4-large**, **voyage-4**, **voyage-4-lite**, **voyage-4-nano** |

Plus **registration fix** — earlier model files were exported but never wired into the provider class's `embeddingModelFactories` map, which meant `getEmbeddingModel(literal)` threw `InvalidModelError`. All providers now dispatch correctly.

## Model specs (verified from official docs)

### `gemini-embedding-2` (Google / Vertex)
| | Value |
|---|---|
| Default output dims | 3072 |
| Supported dims | 128–3072 (Matryoshka — recommended 768 / 1536 / 3072) |
| **Max input tokens** | **8192** (4× v1) |
| Modalities | Text / image / video / audio / PDF (text path wired in this PR) |
| Status | GA (April 2026) |
| Pricing | $0.15 / M input tokens |

### `gemini-embedding-001` (Google / Vertex)
| | Value |
|---|---|
| Default output dims | 3072 |
| Supported dims | 128–3072 (Matryoshka) |
| Max input tokens | 2048 |
| Status | GA (June 2025) |
| Pricing | $0.15 / M |

### `text-embedding-005` (Vertex only)
| | Value |
|---|---|
| Default output dims | 768 |
| Max input tokens | 2048 |
| Status | GA |
| Pricing | $0.10 / M |

### Voyage 4 family (via `anthropic` provider, hits Voyage's API)
| Model | Default dims | Max tokens | Status | Pricing |
|---|---|---|---|---|
| voyage-4-large | 1024 | 32K | GA | $0.18 / M |
| voyage-4 | 1024 | 32K | GA | $0.06 / M |
| voyage-4-lite | 1024 | 32K | GA | $0.02 / M |
| voyage-4-nano (open-weight) | 1024 | 32K | GA | $0.01 / M |

## Why now

Unblocks pegasus' v5 behaviour-clustering pipeline migration to Gemini embeddings at **native 1536-d** (matches existing Qdrant collection — no local dim reduction) and gives the customer the choice between OpenAI text-embedding-3-large @ 1536, Gemini embedding @ 1536, or Voyage 4 family if they prefer.

## Files changed (~15 files, +500 LOC)

| Area | Files |
|---|---|
| Google embedding models | `gemini-embedding-001.google.ts`, `gemini-embedding-2.google.ts`, `index.ts`, `embedding-pricing.json` |
| Vertex embedding models | `gemini-embedding-001.vertex.ts`, `gemini-embedding-2.vertex.ts`, `text-embedding-005.vertex.ts`, `index.ts`, `embedding-pricing.json` |
| Anthropic embedding models | `voyage-4-large.anthropic.ts`, `voyage-4.anthropic.ts`, `voyage-4-lite.anthropic.ts`, `voyage-4-nano.anthropic.ts`, `index.ts`, `embedding-pricing.json` |
| Provider registrations | `provider.google.ts`, `provider.vertex.ts`, `provider.anthropic.ts` |

## Verification

- ✅ `pnpm build` clean across all 14 workspace packages
- ✅ ESM + CJS + DTS builds successful
- ✅ Pricing JSON valid; entries resolve via `embeddingPricingData[Literal]`
- ✅ Provider classes dispatch correctly via `embeddingModelFactories`
- ✅ Each model literal sourced from official docs at PR-creation time

## Coverage after this PR

| Provider | Embedding models registered |
|---|---|
| **openai** | text-embedding-ada-002, text-embedding-3-small, text-embedding-3-large (configurable dims via existing `dimensions` param) |
| **google** | text-embedding-001, text-embedding-004, **gemini-embedding-001**, **gemini-embedding-2** ⭐ |
| **vertex** | text-embedding-004, **text-embedding-005**, text-multilingual-embedding-002, gecko-003, gecko-multilingual-001, **gemini-embedding-001**, **gemini-embedding-2** ⭐ |
| **anthropic** (Voyage) | voyage-2 family (code/finance/law/multilingual), voyage-3 + lite, voyage-3-large, voyage-3.5 + lite, voyage-code-3, **voyage-4**, **voyage-4-large**, **voyage-4-lite**, **voyage-4-nano** ⭐ (14 total) |
| **azure** | proxies OpenAI's lineup |

## What's still out of scope (separate PRs)

| Provider | Missing | Why not now |
|---|---|---|
| **bedrock** | Titan Embed v1/v2, Cohere Embed v3 (en + multilingual) | No `embedding-models` dir or base class exists — needs new scaffold (base class, types, configs, modalities enum). Larger PR. |
| **together-ai** | BGE-large-en-v1.5, M2-BERT-80M-32k, UAE-Large-V1 | Same — `embedding-models` dir is empty, no base class. Needs scaffolding first. |
| **groq** | (no embedding API as of writing) | N/A |
| **multimodal embeddings** (gemini-embedding-2's image/video/audio modes, voyage-multimodal-3) | Modality enum + base class only handle text today | Needs modality enum extension across all embedding model schemas — bigger change |

🤖 Generated with [Claude Code](https://claude.com/claude-code)